### PR TITLE
Loki logging

### DIFF
--- a/kubernetes/server.yml
+++ b/kubernetes/server.yml
@@ -15,6 +15,17 @@ spec:
     spec:
       containers:
         - name: seven-wonders-server
+          env:
+            - name: LOKI_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: loki-credentials
+                  key: username
+            - name: LOKI_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: loki-credentials
+                  key: api-key
           image: hildan/seven-wonders-server:latest
           ports:
             - containerPort: 80

--- a/sw-server/build.gradle.kts
+++ b/sw-server/build.gradle.kts
@@ -24,7 +24,8 @@ dependencies {
     implementation("org.springframework.security:spring-security-messaging")
 
     // logging
-    implementation("ch.qos.logback:logback-classic:1.1.8")
+    implementation("ch.qos.logback:logback-classic:1.2.3")
+    implementation("com.github.loki4j:loki-logback-appender:1.0.0")
 
     // monitoring / metrics
     implementation("org.springframework.boot:spring-boot-starter-actuator")

--- a/sw-server/src/main/kotlin/org/luxons/sevenwonders/server/SevenWonders.kt
+++ b/sw-server/src/main/kotlin/org/luxons/sevenwonders/server/SevenWonders.kt
@@ -20,7 +20,7 @@ class SevenWonders {
     @Bean
     fun metricsCommonTags(): MeterRegistryCustomizer<MeterRegistry>? = MeterRegistryCustomizer { registry ->
         registry.config()
-            .commonTags("application", "SevenWonders")
+            .commonTags("application", "seven-wonders")
             .commonTags("instance", InetAddress.getLocalHost().hostAddress)
     }
 }

--- a/sw-server/src/main/resources/logback.xml
+++ b/sw-server/src/main/resources/logback.xml
@@ -1,0 +1,38 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <appender name="LOKI" class="com.github.loki4j.logback.InstrumentedLoki4jAppender">
+        <!--
+             Loki Cloud hosted solution is limiting the batch size to 65536 Bytes, our log lines are exceeding this
+             limit quite often so we are sending them with a granularity of 1 instead of the default 1000.
+             The library does not provide a `batchSize` expressed in Bytes yet, so we cannot set it smarter than that.
+        -->
+        <batchSize>1</batchSize>
+        <batchTimeoutMs>10000</batchTimeoutMs>
+        <http>
+            <url>https://logs-prod-us-central1.grafana.net/loki/api/v1/push</url>
+            <auth>
+                <username>${LOKI_USERNAME}</username>
+                <password>${LOKI_PASSWORD}</password>
+            </auth>
+            <requestTimeoutMs>15000</requestTimeoutMs>
+        </http>
+        <format>
+            <label>
+                <pattern>application=seven-wonders,instance=${HOSTNAME},level=%level,class=%logger</pattern>
+            </label>
+            <message>
+                <pattern>level=%level class=%logger thread=%thread | %msg %ex</pattern>
+            </message>
+        </format>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+    <root level="INFO">
+        <appender-ref ref="LOKI"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
Add Loki logback appender to push server logs to the free cloud hosted Loki instance provided by Grafana.com.

It also upgrade `ch.qos.logback:logback-classic` to `1.2.3` for compatibility with `com.github.loki4j:loki-logback-appender` (got `ClassNotFoundException` at runtime).