### PR TITLE
Redirect to home when session is lost on game list refresh

### DIFF
--- a/sw-ui/src/jsMain/kotlin/org/luxons/sevenwonders/ui/components/gameBrowser/GameBrowser.kt
+++ b/sw-ui/src/jsMain/kotlin/org/luxons/sevenwonders/ui/components/gameBrowser/GameBrowser.kt
@@ -4,14 +4,24 @@ import blueprintjs.core.*
 import emotion.react.*
 import org.luxons.sevenwonders.ui.components.*
 import org.luxons.sevenwonders.ui.redux.*
+import org.luxons.sevenwonders.ui.router.SwRoute
 import org.luxons.sevenwonders.ui.utils.*
 import react.*
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.h1
 import react.dom.html.ReactHTML.h2
+import react.router.*
 import web.cssom.*
 
 val GameBrowser = FC {
+    val connectedPlayer = useSwSelector { it.connectedPlayer }
+    if (connectedPlayer == null) {
+        Navigate {
+            to = SwRoute.HOME.path
+            replace = true
+        }
+        return@FC
+    }
     div {
         css(GlobalStyles.fullscreen, GlobalStyles.zeusBackground) {
             padding = Padding(all = 1.rem)


### PR DESCRIPTION
Fixes #168.

When a user refreshes the game list page, the Redux state (including `connectedPlayer`) is lost. `GameList`'s `mapStateToProps` called `error("there should be a connected player")` on the null value, producing a raw stacktrace in the UI.

**Fix:** Check `connectedPlayer` at the top of `GameBrowser` before any child components render. If it's null (session lost), redirect to the home page using the same `Navigate` pattern already used in the catch-all route in `Application.kt`. The user is taken back to the name entry screen to start a fresh session cleanly.